### PR TITLE
Fixing bug when log folder does not exist

### DIFF
--- a/src/util/logger.py
+++ b/src/util/logger.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from constant import logger as constant_logger
 
@@ -11,6 +12,8 @@ def create_logger(name: str) -> logging.Logger:
     """
     path = constant_logger.LOGGING_PATH + name + ".log"
 
+    if os.path.isdir("log") == False:
+        os.mkdir("log")
     handler = logging.FileHandler(path)
     handler.setFormatter(logging.Formatter(constant_logger.LOGGING_FORMAT))
 


### PR DESCRIPTION
When no dir named log existed the program failed to start. So now there is a if check to check if such a dir exists. If not it is created.